### PR TITLE
Add withRelationships scope to prevent N+1 queries

### DIFF
--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -82,9 +82,18 @@ class Product extends Model
         return route('product.detail', $this);
     }
 
-    public function scopeActive(Builder $builder)
+    public function scopeActive(Builder $builder): void
     {
         $builder->where('active', 1);
+    }
+
+    /**
+     * Scope to eager load common relationships and prevent N+1 queries.
+     * Use this when loading collections of products.
+     */
+    public function scopeWithRelationships(Builder $builder): void
+    {
+        $builder->with(['category', 'categories', 'suppliers', 'media']);
     }
 
     public function category(): BelongsTo


### PR DESCRIPTION
## Problem

When loading collections of products, related models (categories, suppliers, media) are loaded individually per product, causing N+1 query issues.

## Solution

Add a `scopeWithRelationships()` method that eager loads `category`, `categories`, `suppliers`, and `media` relationships. Usage:

```php
Product::withRelationships()->get();
Product::active()->withRelationships()->get();
```

This is opt-in via the scope, so it's a non-breaking change.